### PR TITLE
Release v0.9.2

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -21,9 +21,9 @@ jobs:
       - name: Restore dependencies
         run: dotnet restore
       - name: Build
-        run: dotnet build --no-restore -c Release
+        run: dotnet build -c Release --no-restore
       - name: Test
-        run: dotnet test test/Routine.Test/Routine.Test.csproj --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura
+        run: dotnet test test/Routine.Test/Routine.Test.csproj -c Release --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura
       - name: Code Coverage Summary Report
         uses: 5monkeys/cobertura-action@master
         with:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Restore dependencies
         run: dotnet restore
       - name: Build
-        run: dotnet build --no-restore
+        run: dotnet build --no-restore -c Release
       - name: Test
-        run: dotnet test --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura
+        run: dotnet test test/Routine.Test/Routine.Test.csproj --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura
       - name: Code Coverage Summary Report
         uses: 5monkeys/cobertura-action@master
         with:
-          path: ${{ github.workspace }}/test/*/coverage.cobertura.xml
+          path: ${{ github.workspace }}/test/Routine.Test/coverage.cobertura.xml
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           minimum_coverage: 70
           skip_covered: false

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Code Coverage Summary Report
         uses: 5monkeys/cobertura-action@master
         with:
-          path: ${{ github.workspace }}/test/Routine.Test/coverage.cobertura.xml
+          path: test/Routine.Test/coverage.cobertura.xml
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           minimum_coverage: 70
           skip_covered: false


### PR DESCRIPTION
# Release v0.9.2

Final .NET 5 sürümü yayınlanacak, böylece Gazel tarafındaki geçiş
başlayabilecek.

## Tasks

- [x] performance test kosmasin, gereksiz coverage cikiyor
- [x] debug'da build ediyor, release'e cekilecek
- [x] cobertura neden calismiyor bakilacak

