### PR TITLE
Issue / .NET 6 / Migrate Rest Client Exceptions

### DIFF
--- a/test/Routine.Test/Service/RestClientObjectServiceTest.cs
+++ b/test/Routine.Test/Service/RestClientObjectServiceTest.cs
@@ -64,6 +64,7 @@ public class RestClientObjectServiceTest<TRestClientStubber, TDoInvoker> : CoreT
 
     private static WebException HttpNotFound(string message)
     {
+        Assert.Fail("migrate web exceptions to http client exceptions");
         var mock = new Mock<HttpWebResponse>();
         mock.Setup(wr => wr.StatusCode).Returns(HttpStatusCode.NotFound);
         mock.Setup(wr => wr.StatusDescription).Returns(message);


### PR DESCRIPTION
Yeni rest client'in exception'inin handle edilmesi saglanmali. Su an
HttpWebResponse'a depend ediyor.