### PR TITLE
Issue / Domain Type Init

### DIFF
--- a/src/Routine/Constants.cs
+++ b/src/Routine/Constants.cs
@@ -8,7 +8,6 @@ internal class Constants
 
     public const int FIRST_DEPTH = 1;
 
-    public const string CACHE_DOMAIN_TYPES = "__routine_domain_types";
     public const string CACHE_APPLICATION_MODEL = "__routine_application_model";
 
     public const string INITIALIZER_ID = "__routine_initializer";

--- a/src/Routine/ContextBuilder.cs
+++ b/src/Routine/ContextBuilder.cs
@@ -51,7 +51,7 @@ public class ContextBuilder
 
     public IClientContext AsClientApplication(ICodingStyle codingStyle)
     {
-        var coreContext = new DefaultCoreContext(codingStyle, Cache);
+        var coreContext = new DefaultCoreContext(codingStyle);
         var service = new ObjectService(coreContext, Cache).Intercept(InterceptionConfiguration);
 
         return new DefaultClientContext(service, new Rapplication(service));
@@ -59,7 +59,7 @@ public class ContextBuilder
 
     public IServiceContext AsServiceApplication(IServiceConfiguration serviceConfiguration, ICodingStyle codingStyle)
     {
-        var coreContext = new DefaultCoreContext(codingStyle, Cache);
+        var coreContext = new DefaultCoreContext(codingStyle);
         var service = new ObjectService(coreContext, Cache).Intercept(InterceptionConfiguration);
 
         return new DefaultServiceContext(coreContext, serviceConfiguration, service);

--- a/src/Routine/Core/Cache/DictionaryCache.cs
+++ b/src/Routine/Core/Cache/DictionaryCache.cs
@@ -6,7 +6,7 @@ public class DictionaryCache : ICache
 
     public DictionaryCache()
     {
-        dictionary = new Dictionary<string, object>();
+        dictionary = new();
     }
 
     public object this[string key]

--- a/src/Routine/Core/Reflection/ReflectionOptimizer.cs
+++ b/src/Routine/Core/Reflection/ReflectionOptimizer.cs
@@ -60,6 +60,14 @@ internal class ReflectionOptimizer
         }
     }
 
+    public static void ClearOptimizeList()
+    {
+        lock (OPTIMIZE_LIST_LOCK)
+        {
+            OPTIMIZE_LIST.Clear();
+        }
+    }
+
     private readonly List<MethodBase> methods;
 
     private ReflectionOptimizer(List<MethodBase> methods)

--- a/src/Routine/Engine/Configuration/ConventionBased/ConventionBasedCodingStyle.cs
+++ b/src/Routine/Engine/Configuration/ConventionBased/ConventionBasedCodingStyle.cs
@@ -40,6 +40,8 @@ public class ConventionBasedCodingStyle : LayeredBase<ConventionBasedCodingStyle
 
     public ConventionBasedCodingStyle()
     {
+        TypeInfo.Clear();
+
         types = new();
 
         MaxFetchDepth = new(this, nameof(MaxFetchDepth), true);
@@ -137,8 +139,6 @@ public class ConventionBasedCodingStyle : LayeredBase<ConventionBasedCodingStyle
 
         TypeInfo.Optimize(types);
 
-        NeedRefresh();
-
         AddTypes(types.Select(t => TypeInfo.Get(t) as IType));
 
         AddNullableTypes(types);
@@ -169,22 +169,6 @@ public class ConventionBasedCodingStyle : LayeredBase<ConventionBasedCodingStyle
         }
     }
 
-    private bool needsRefresh;
-    private void NeedRefresh() { needsRefresh = true; }
-    private void RefreshIfNecessary()
-    {
-        if (!needsRefresh) { return; }
-
-        needsRefresh = false;
-
-        //TODO refactor - TypeInfo should handle this by itself. Proxy instances should be given, so that domain type changes affects immediately
-        foreach (TypeInfo type in types.Where(t => t is TypeInfo).ToList())
-        {
-            types.Remove(type);
-            types.Add(TypeInfo.Get(type.GetActualType()));
-        }
-    }
-
     private void AddNullableTypes(Type[] types)
     {
         if (types.Length <= 0) { return; }
@@ -201,8 +185,8 @@ public class ConventionBasedCodingStyle : LayeredBase<ConventionBasedCodingStyle
 
     int ICodingStyle.GetMaxFetchDepth() => MaxFetchDepth.Get();
 
-    List<IType> ICodingStyle.GetTypes() { RefreshIfNecessary(); return types.ToList(); }
-    bool ICodingStyle.ContainsType(IType type) { RefreshIfNecessary(); return types.Contains(type); }
+    List<IType> ICodingStyle.GetTypes() => types.ToList();
+    bool ICodingStyle.ContainsType(IType type) => types.Contains(type);
 
     IType ICodingStyle.GetType(object @object) => Type.Get(@object);
 

--- a/src/Routine/Engine/Context/TypeNotFoundException.cs
+++ b/src/Routine/Engine/Context/TypeNotFoundException.cs
@@ -1,0 +1,16 @@
+namespace Routine.Engine.Context;
+
+public class TypeNotFoundException : Exception
+{
+    public string TypeId { get; }
+
+    public TypeNotFoundException(string typeId)
+        : base(
+            $"Type could not be found with given type id: '{typeId}'. Make sure type id is correct and corresponding type is configured. " +
+            "This can occur when a client with old version of service model tries to connect to server with a new version of service model. " +
+            "Also make sure that ObjectService.GetApplicationModel is called before any other ObjectService methods are called " +
+            "(This is because domain type of the expected type should be accessed via IType before trying to access via type id).")
+    {
+        TypeId = typeId;
+    }
+}

--- a/src/Routine/Engine/DataDoesNotExistException.cs
+++ b/src/Routine/Engine/DataDoesNotExistException.cs
@@ -1,0 +1,7 @@
+namespace Routine.Engine;
+
+public class DataDoesNotExistException : Exception
+{
+    public DataDoesNotExistException(string objectModelId, string dataName)
+        : base($"Data '{dataName}' does not exist on Object '{objectModelId}'") { }
+}

--- a/src/Routine/Engine/ICoreContext.cs
+++ b/src/Routine/Engine/ICoreContext.cs
@@ -5,9 +5,12 @@ namespace Routine.Engine;
 public interface ICoreContext
 {
     ICodingStyle CodingStyle { get; }
+    List<DomainType> DomainTypes { get; }
+
+    void BuildDomainTypes();
+
     DomainType GetDomainType(string typeId);
     DomainType GetDomainType(IType type);
-    List<DomainType> GetDomainTypes();
 
     Task<object> GetObjectAsync(ReferenceData reference);
     Task<DomainObject> GetDomainObjectAsync(ReferenceData reference);

--- a/src/Routine/Engine/MissingParameterException.cs
+++ b/src/Routine/Engine/MissingParameterException.cs
@@ -1,0 +1,7 @@
+namespace Routine.Engine;
+
+public class MissingParameterException : Exception
+{
+    public MissingParameterException(string objectModelId, string operationName, string parameterName)
+        : base($"Parameter '{parameterName}' was not given for Operation '{operationName} on Object '{objectModelId}'") { }
+}

--- a/src/Routine/Engine/ObjectService.cs
+++ b/src/Routine/Engine/ObjectService.cs
@@ -49,17 +49,17 @@ public class ObjectService : IObjectService
 public class DataDoesNotExistException : Exception
 {
     public DataDoesNotExistException(string objectModelId, string dataName)
-        : base("Data '" + dataName + "' does not exist on Object '" + objectModelId + "'") { }
+        : base($"Data '{dataName}' does not exist on Object '{objectModelId}'") { }
 }
 
 public class OperationDoesNotExistException : Exception
 {
     public OperationDoesNotExistException(string objectModelId, string operationName)
-        : base("Operation '" + operationName + "' does not exist on Object '" + objectModelId + "'") { }
+        : base($"Operation '{operationName}' does not exist on Object '{objectModelId}'") { }
 }
 
 public class MissingParameterException : Exception
 {
     public MissingParameterException(string objectModelId, string operationName, string parameterName)
-        : base("Parameter '" + parameterName + "' was not given for Operation '" + operationName + " on Object '" + objectModelId + "'") { }
+        : base($"Parameter '{parameterName}' was not given for Operation '{operationName} on Object '{objectModelId}'") { }
 }

--- a/src/Routine/Engine/ObjectService.cs
+++ b/src/Routine/Engine/ObjectService.cs
@@ -1,5 +1,5 @@
-using Routine.Core.Cache;
 using Routine.Core;
+using Routine.Core.Cache;
 using Routine.Core.Runtime;
 
 using static Routine.Constants;
@@ -21,21 +21,23 @@ public class ObjectService : IObjectService
     {
         get
         {
-            if (!cache.Contains(CACHE_APPLICATION_MODEL))
+            var result = (ApplicationModel)cache[CACHE_APPLICATION_MODEL];
+            if (result == null)
             {
                 lock (cache)
                 {
-                    if (!cache.Contains(CACHE_APPLICATION_MODEL))
+                    if ((result = (ApplicationModel)cache[CACHE_APPLICATION_MODEL]) == null)
                     {
-                        cache.Add(CACHE_APPLICATION_MODEL, new ApplicationModel
-                        {
-                            Models = ctx.GetDomainTypes().Select(dt => dt.GetModel()).ToList()
-                        });
+                        ctx.BuildDomainTypes();
+
+                        result = new() { Models = ctx.DomainTypes.Select(dt => dt.GetModel()).ToList() };
+
+                        cache.Add(CACHE_APPLICATION_MODEL, result);
                     }
                 }
             }
 
-            return cache[CACHE_APPLICATION_MODEL] as ApplicationModel;
+            return result;
         }
     }
 
@@ -44,22 +46,4 @@ public class ObjectService : IObjectService
 
     public VariableData Do(ReferenceData target, string operation, Dictionary<string, ParameterValueData> parameters) => ctx.GetDomainObjectAsync(target).WaitAndGetResult().Perform(operation, parameters);
     public async Task<VariableData> DoAsync(ReferenceData target, string operation, Dictionary<string, ParameterValueData> parameters) => await (await ctx.GetDomainObjectAsync(target)).PerformAsync(operation, parameters);
-}
-
-public class DataDoesNotExistException : Exception
-{
-    public DataDoesNotExistException(string objectModelId, string dataName)
-        : base($"Data '{dataName}' does not exist on Object '{objectModelId}'") { }
-}
-
-public class OperationDoesNotExistException : Exception
-{
-    public OperationDoesNotExistException(string objectModelId, string operationName)
-        : base($"Operation '{operationName}' does not exist on Object '{objectModelId}'") { }
-}
-
-public class MissingParameterException : Exception
-{
-    public MissingParameterException(string objectModelId, string operationName, string parameterName)
-        : base($"Parameter '{parameterName}' was not given for Operation '{operationName} on Object '{objectModelId}'") { }
 }

--- a/src/Routine/Engine/OperationDoesNotExistException.cs
+++ b/src/Routine/Engine/OperationDoesNotExistException.cs
@@ -1,0 +1,7 @@
+namespace Routine.Engine;
+
+public class OperationDoesNotExistException : Exception
+{
+    public OperationDoesNotExistException(string objectModelId, string operationName)
+        : base($"Operation '{operationName}' does not exist on Object '{objectModelId}'") { }
+}

--- a/src/Routine/Engine/Reflection/ArrayTypeInfo.cs
+++ b/src/Routine/Engine/Reflection/ArrayTypeInfo.cs
@@ -6,17 +6,17 @@ internal class ArrayTypeInfo : PreloadedTypeInfo
 
     internal ArrayTypeInfo(Type type) : base(type)
     {
-        IsArray = true;
+        SetIsArray(true);
     }
 
-    protected override void Load()
+    protected internal override void Load()
     {
         base.Load();
 
         elementType = Get(type.GetElementType());
     }
 
-    protected override TypeInfo GetElementType() => elementType;
+    protected internal override TypeInfo GetElementType() => elementType;
     public override object CreateInstance() => CreateListInstance(0);
     public override IList CreateListInstance(int length) => Array.CreateInstance(elementType.GetActualType(), length);
 }

--- a/src/Routine/Engine/Reflection/BaseTypeInfo.cs
+++ b/src/Routine/Engine/Reflection/BaseTypeInfo.cs
@@ -1,0 +1,117 @@
+namespace Routine.Engine.Reflection;
+
+public abstract class BaseTypeInfo : TypeInfo
+{
+    protected readonly Type type;
+
+    private bool isVoid;
+    private bool isEnum;
+    private bool isArray;
+
+    protected BaseTypeInfo(Type type)
+    {
+        this.type = type;
+
+        IsPublic = type.IsPublic;
+        IsAbstract = type.IsAbstract;
+        IsInterface = type.IsInterface;
+        IsValueType = type.IsValueType;
+        IsGenericType = type.IsGenericType;
+        IsPrimitive = type.IsPrimitive;
+    }
+
+    public override Type GetActualType() => type;
+
+    public override bool IsPublic { get; }
+    public override bool IsAbstract { get; }
+    public override bool IsInterface { get; }
+    public override bool IsValueType { get; }
+    public override bool IsGenericType { get; }
+    public override bool IsPrimitive { get; }
+
+    public override bool IsVoid => isVoid;
+    public override bool IsEnum => isEnum;
+    public override bool IsArray => isArray;
+
+    protected void SetIsVoid(bool isVoid) => this.isVoid = isVoid;
+    protected void SetIsEnum(bool isEnum) => this.isEnum = isEnum;
+    protected void SetIsArray(bool isArray) => this.isArray = isArray;
+
+    public override List<string> GetEnumNames() => new();
+    public override List<object> GetEnumValues() => new();
+    protected internal override TypeInfo GetEnumUnderlyingType() => null;
+
+    protected internal override TypeInfo[] GetAssignableTypes()
+    {
+        var result = new List<TypeInfo> { Get<object>() };
+
+        FillInheritance(this, result);
+
+        foreach (var typeInfo in GetInterfaces())
+        {
+            FillInheritance(typeInfo, result);
+        }
+
+        return result.ToArray();
+    }
+
+    protected static void FillInheritance(TypeInfo root, List<TypeInfo> state)
+    {
+        var cur = root;
+        while (cur != null)
+        {
+            if (!state.Contains(cur))
+            {
+                state.Add(cur);
+            }
+
+            cur = cur.BaseType;
+        }
+    }
+
+    public override List<ConstructorInfo> GetPublicConstructors() => GetAllConstructors().Where(c => c.IsPublic).ToList();
+
+    public override ConstructorInfo GetConstructor(params TypeInfo[] typeInfos)
+    {
+        if (typeInfos.Length > 0)
+        {
+            var first = typeInfos[0];
+            var rest = Enumerable.Range(1, typeInfos.Length - 1).Select(i => (IType)typeInfos[i]).ToArray();
+
+            return GetAllConstructors().SingleOrDefault(c => c.HasParameters(first, rest));
+        }
+
+        return GetAllConstructors().SingleOrDefault(c => c.HasNoParameters());
+    }
+
+    public override ICollection<PropertyInfo> GetPublicProperties(bool onlyPublicReadableAndWritables = false)
+    {
+        if (onlyPublicReadableAndWritables)
+        {
+            return GetAllProperties().Where(p => p.IsPubliclyReadable && p.IsPubliclyWritable).ToList();
+        }
+
+        return GetAllProperties().Where(p => p.IsPubliclyReadable).ToList();
+    }
+
+    public override ICollection<PropertyInfo> GetPublicStaticProperties(bool onlyPublicReadableAndWritables = false)
+    {
+        if (onlyPublicReadableAndWritables)
+        {
+            return GetAllStaticProperties().Where(p => p.IsPubliclyReadable && p.IsPubliclyWritable).ToList();
+        }
+
+        return GetAllStaticProperties().Where(p => p.IsPubliclyReadable).ToList();
+    }
+
+    public override PropertyInfo GetProperty(string name) => GetAllProperties().SingleOrDefault(p => p.Name == name);
+    public override List<PropertyInfo> GetProperties(string name) => GetAllProperties().Where(p => p.Name == name).ToList();
+    public override PropertyInfo GetStaticProperty(string name) => GetAllStaticProperties().SingleOrDefault(p => p.Name == name);
+    public override List<PropertyInfo> GetStaticProperties(string name) => GetAllStaticProperties().Where(p => p.Name == name).ToList();
+    public override ICollection<MethodInfo> GetPublicMethods() => GetAllMethods().Where(m => m.IsPublic).ToList();
+    public override ICollection<MethodInfo> GetPublicStaticMethods() => GetAllStaticMethods().Where(m => m.IsPublic).ToList();
+    public override MethodInfo GetMethod(string name) => GetAllMethods().SingleOrDefault(m => m.Name == name);
+    public override List<MethodInfo> GetMethods(string name) => GetAllMethods().Where(m => m.Name == name).ToList();
+    public override MethodInfo GetStaticMethod(string name) => GetAllStaticMethods().SingleOrDefault(m => m.Name == name);
+    public override List<MethodInfo> GetStaticMethods(string name) => GetAllStaticMethods().Where(m => m.Name == name).ToList();
+}

--- a/src/Routine/Engine/Reflection/EnumTypeInfo.cs
+++ b/src/Routine/Engine/Reflection/EnumTypeInfo.cs
@@ -9,7 +9,7 @@ internal class EnumTypeInfo : PreloadedTypeInfo
     internal EnumTypeInfo(Type type)
         : base(type)
     {
-        IsEnum = true;
+        SetIsEnum(true);
 
         enumNames = type.GetEnumNames().ToList();
         enumValues = type.GetEnumValues().Cast<object>().ToList();
@@ -18,5 +18,5 @@ internal class EnumTypeInfo : PreloadedTypeInfo
 
     public override List<string> GetEnumNames() => enumNames;
     public override List<object> GetEnumValues() => enumValues;
-    protected override TypeInfo GetEnumUnderlyingType() => enumUnderlyingType;
+    protected internal override TypeInfo GetEnumUnderlyingType() => enumUnderlyingType;
 }

--- a/src/Routine/Engine/Reflection/OptimizedTypeInfo.cs
+++ b/src/Routine/Engine/Reflection/OptimizedTypeInfo.cs
@@ -22,7 +22,7 @@ internal class OptimizedTypeInfo : PreloadedTypeInfo
     internal OptimizedTypeInfo(Type type)
         : base(type) { }
 
-    protected override void Load()
+    protected internal override void Load()
     {
         base.Load();
 
@@ -63,7 +63,7 @@ internal class OptimizedTypeInfo : PreloadedTypeInfo
     public override PropertyInfo[] GetAllStaticProperties() => allStaticProperties;
     public override MethodInfo[] GetAllMethods() => allMethods;
     public override MethodInfo[] GetAllStaticMethods() => allStaticMethods;
-    protected override MethodInfo GetParseMethod() => parseMethod;
+    protected internal override MethodInfo GetParseMethod() => parseMethod;
 
     public override PropertyInfo GetProperty(string name) => allPropertiesNameIndex.GetFirstOrDefault(name);
     public override List<PropertyInfo> GetProperties(string name) => allPropertiesNameIndex.GetAll(name);

--- a/src/Routine/Engine/Reflection/ParseableTypeInfo.cs
+++ b/src/Routine/Engine/Reflection/ParseableTypeInfo.cs
@@ -7,7 +7,7 @@ internal class ParseableTypeInfo : PreloadedTypeInfo
     internal ParseableTypeInfo(Type type)
         : base(type) { }
 
-    protected override void Load()
+    protected internal override void Load()
     {
         base.Load();
 
@@ -21,5 +21,5 @@ internal class ParseableTypeInfo : PreloadedTypeInfo
         }
     }
 
-    protected override MethodInfo GetParseMethod() => parseMethod;
+    protected internal override MethodInfo GetParseMethod() => parseMethod;
 }

--- a/src/Routine/Engine/Reflection/PreloadedTypeInfo.cs
+++ b/src/Routine/Engine/Reflection/PreloadedTypeInfo.cs
@@ -1,6 +1,6 @@
 ﻿namespace Routine.Engine.Reflection;
 
-public abstract class PreloadedTypeInfo : TypeInfo
+public abstract class PreloadedTypeInfo : BaseTypeInfo
 {
     private string name;
     private string fullName;
@@ -19,7 +19,7 @@ public abstract class PreloadedTypeInfo : TypeInfo
     protected PreloadedTypeInfo(Type type)
         : base(type) { }
 
-    protected override void Load()
+    protected internal override void Load()
     {
         name = type.Name;
         fullName = type.FullName;
@@ -33,12 +33,12 @@ public abstract class PreloadedTypeInfo : TypeInfo
         customAttributes = type.GetCustomAttributes(true);
     }
 
-    protected override TypeInfo[] GetAssignableTypes() => assignableTypes;
+    protected internal override TypeInfo[] GetAssignableTypes() => assignableTypes;
 
-    protected override TypeInfo[] GetGenericArguments() => genericArguments;
-    protected override TypeInfo[] GetInterfaces() => interfaces;
+    protected internal override TypeInfo[] GetGenericArguments() => genericArguments;
+    protected internal override TypeInfo[] GetInterfaces() => interfaces;
     public override bool CanBe(TypeInfo other) => assignableTypes.Any(t => t == other);
-    protected override TypeInfo GetElementType() => null;
+    protected internal override TypeInfo GetElementType() => null;
     public override ConstructorInfo[] GetAllConstructors() => Array.Empty<ConstructorInfo>();
     public override PropertyInfo[] GetAllProperties() => Array.Empty<PropertyInfo>();
     public override PropertyInfo[] GetAllStaticProperties() => Array.Empty<PropertyInfo>();
@@ -46,7 +46,7 @@ public abstract class PreloadedTypeInfo : TypeInfo
     public override MethodInfo[] GetAllStaticMethods() => Array.Empty<MethodInfo>();
     public override object[] GetCustomAttributes() => customAttributes;
 
-    protected override MethodInfo GetParseMethod() => null;
+    protected internal override MethodInfo GetParseMethod() => null;
 
     public override object CreateInstance() => Activator.CreateInstance(type);
     public override IList CreateListInstance(int length) => (IList)Activator.CreateInstance(type, length);

--- a/src/Routine/Engine/Reflection/ProxyTypeInfo.cs
+++ b/src/Routine/Engine/Reflection/ProxyTypeInfo.cs
@@ -4,12 +4,16 @@ internal class ProxyTypeInfo : TypeInfo
 {
     private volatile TypeInfo real;
 
-    internal ProxyTypeInfo(TypeInfo real)
+    internal TypeInfo Real
     {
-        this.real = real ?? throw new ArgumentNullException(nameof(real));
+        get => real;
+        set => real = value ?? throw new ArgumentNullException(nameof(real));
     }
 
-    internal void SetReal(TypeInfo real) => this.real = real ?? throw new ArgumentNullException(nameof(real));
+    internal ProxyTypeInfo(TypeInfo real)
+    {
+        Real = real;
+    }
 
     public override bool IsPublic => real.IsPublic;
     public override bool IsAbstract => real.IsAbstract;

--- a/src/Routine/Engine/Reflection/ProxyTypeInfo.cs
+++ b/src/Routine/Engine/Reflection/ProxyTypeInfo.cs
@@ -1,0 +1,60 @@
+namespace Routine.Engine.Reflection;
+
+internal class ProxyTypeInfo : TypeInfo
+{
+    private volatile TypeInfo real;
+
+    internal ProxyTypeInfo(TypeInfo real)
+    {
+        this.real = real ?? throw new ArgumentNullException(nameof(real));
+    }
+
+    internal void SetReal(TypeInfo real) => this.real = real ?? throw new ArgumentNullException(nameof(real));
+
+    public override bool IsPublic => real.IsPublic;
+    public override bool IsAbstract => real.IsAbstract;
+    public override bool IsInterface => real.IsInterface;
+    public override bool IsValueType => real.IsValueType;
+    public override bool IsGenericType => real.IsGenericType;
+    public override bool IsPrimitive => real.IsPrimitive;
+    public override bool IsVoid => real.IsVoid;
+    public override bool IsEnum => real.IsEnum;
+    public override bool IsArray => real.IsArray;
+    public override string Name => real.Name;
+    public override string FullName => real.FullName;
+    public override string Namespace => real.Namespace;
+    public override TypeInfo BaseType => real.BaseType;
+
+    public override bool CanBe(TypeInfo other) => real.CanBe(other);
+    public override object CreateInstance() => real.CreateInstance();
+    public override IList CreateListInstance(int length) => real.CreateListInstance(length);
+
+    public override Type GetActualType() => real.GetActualType();
+    public override ConstructorInfo[] GetAllConstructors() => real.GetAllConstructors();
+    public override MethodInfo[] GetAllMethods() => real.GetAllMethods();
+    public override PropertyInfo[] GetAllProperties() => real.GetAllProperties();
+    public override MethodInfo[] GetAllStaticMethods() => real.GetAllStaticMethods();
+    public override PropertyInfo[] GetAllStaticProperties() => real.GetAllStaticProperties();
+    public override ConstructorInfo GetConstructor(params TypeInfo[] typeInfos) => real.GetConstructor(typeInfos);
+    public override object[] GetCustomAttributes() => real.GetCustomAttributes();
+    public override MethodInfo GetMethod(string name) => real.GetMethod(name);
+    public override List<MethodInfo> GetMethods(string name) => real.GetMethods(name);
+    public override List<PropertyInfo> GetProperties(string name) => real.GetProperties(name);
+    public override PropertyInfo GetProperty(string name) => real.GetProperty(name);
+    public override List<ConstructorInfo> GetPublicConstructors() => real.GetPublicConstructors();
+    public override ICollection<MethodInfo> GetPublicMethods() => real.GetPublicMethods();
+    public override ICollection<PropertyInfo> GetPublicProperties(bool onlyPublicReadableAndWritables = false) => real.GetPublicProperties(onlyPublicReadableAndWritables);
+    public override ICollection<MethodInfo> GetPublicStaticMethods() => real.GetPublicStaticMethods();
+    public override ICollection<PropertyInfo> GetPublicStaticProperties(bool onlyPublicReadableAndWritables = false) => real.GetPublicStaticProperties(onlyPublicReadableAndWritables);
+    public override MethodInfo GetStaticMethod(string name) => real.GetStaticMethod(name);
+    public override List<MethodInfo> GetStaticMethods(string name) => real.GetStaticMethods(name);
+    public override List<PropertyInfo> GetStaticProperties(string name) => real.GetStaticProperties(name);
+    public override PropertyInfo GetStaticProperty(string name) => real.GetStaticProperty(name);
+    protected internal override TypeInfo[] GetAssignableTypes() => real.GetAssignableTypes();
+    protected internal override TypeInfo GetElementType() => real.GetElementType();
+    protected internal override TypeInfo GetEnumUnderlyingType() => real.GetEnumUnderlyingType();
+    protected internal override TypeInfo[] GetGenericArguments() => real.GetGenericArguments();
+    protected internal override TypeInfo[] GetInterfaces() => real.GetInterfaces();
+    protected internal override MethodInfo GetParseMethod() => real.GetParseMethod();
+    protected internal override void Load() => real.Load();
+}

--- a/src/Routine/Engine/Reflection/ProxyTypeInfo.cs
+++ b/src/Routine/Engine/Reflection/ProxyTypeInfo.cs
@@ -28,7 +28,6 @@ internal class ProxyTypeInfo : TypeInfo
     public override bool CanBe(TypeInfo other) => real.CanBe(other);
     public override object CreateInstance() => real.CreateInstance();
     public override IList CreateListInstance(int length) => real.CreateListInstance(length);
-
     public override Type GetActualType() => real.GetActualType();
     public override ConstructorInfo[] GetAllConstructors() => real.GetAllConstructors();
     public override MethodInfo[] GetAllMethods() => real.GetAllMethods();
@@ -52,7 +51,9 @@ internal class ProxyTypeInfo : TypeInfo
     public override PropertyInfo GetStaticProperty(string name) => real.GetStaticProperty(name);
     protected internal override TypeInfo[] GetAssignableTypes() => real.GetAssignableTypes();
     protected internal override TypeInfo GetElementType() => real.GetElementType();
+    public override List<string> GetEnumNames() => real.GetEnumNames();
     protected internal override TypeInfo GetEnumUnderlyingType() => real.GetEnumUnderlyingType();
+    public override List<object> GetEnumValues() => real.GetEnumValues();
     protected internal override TypeInfo[] GetGenericArguments() => real.GetGenericArguments();
     protected internal override TypeInfo[] GetInterfaces() => real.GetInterfaces();
     protected internal override MethodInfo GetParseMethod() => real.GetParseMethod();

--- a/src/Routine/Engine/Reflection/ReflectedTypeInfo.cs
+++ b/src/Routine/Engine/Reflection/ReflectedTypeInfo.cs
@@ -1,6 +1,6 @@
 namespace Routine.Engine.Reflection;
 
-internal class ReflectedTypeInfo : TypeInfo
+internal class ReflectedTypeInfo : BaseTypeInfo
 {
     internal ReflectedTypeInfo(Type type)
         : base(type) { }
@@ -11,13 +11,13 @@ internal class ReflectedTypeInfo : TypeInfo
     public override MethodInfo[] GetAllMethods() => type.GetMethods(ALL_INSTANCE).Where(m => !m.IsSpecialName).Select(MethodInfo.Reflected).ToArray();
     public override MethodInfo[] GetAllStaticMethods() => type.GetMethods(ALL_STATIC).Where(m => !m.IsSpecialName).Select(MethodInfo.Reflected).ToArray();
     public override object[] GetCustomAttributes() => type.GetCustomAttributes(true);
-    protected override TypeInfo[] GetGenericArguments() => type.GetGenericArguments().Select(Get).ToArray();
-    protected override TypeInfo GetElementType() => Get(type.GetElementType());
-    protected override TypeInfo[] GetInterfaces() => type.GetInterfaces().Select(Get).ToArray();
+    protected internal override TypeInfo[] GetGenericArguments() => type.GetGenericArguments().Select(Get).ToArray();
+    protected internal override TypeInfo GetElementType() => Get(type.GetElementType());
+    protected internal override TypeInfo[] GetInterfaces() => type.GetInterfaces().Select(Get).ToArray();
     public override bool CanBe(TypeInfo other) => other.GetActualType().IsAssignableFrom(type);
-    protected override MethodInfo GetParseMethod() => null;
+    protected internal override MethodInfo GetParseMethod() => null;
 
-    protected override void Load() { }
+    protected internal override void Load() { }
 
     public override string Name => type.Name;
     public override string FullName => type.FullName;

--- a/src/Routine/Engine/Reflection/VoidTypeInfo.cs
+++ b/src/Routine/Engine/Reflection/VoidTypeInfo.cs
@@ -5,6 +5,6 @@ internal class VoidTypeInfo : PreloadedTypeInfo
     internal VoidTypeInfo()
         : base(typeof(void))
     {
-        IsVoid = true;
+        SetIsVoid(true);
     }
 }

--- a/src/Routine/TypeInfo.cs
+++ b/src/Routine/TypeInfo.cs
@@ -139,8 +139,8 @@ public abstract class TypeInfo : IType
     protected internal abstract TypeInfo GetElementType();
     protected internal abstract TypeInfo[] GetInterfaces();
     public abstract bool CanBe(TypeInfo other);
-    public virtual List<string> GetEnumNames() => new();
-    public virtual List<object> GetEnumValues() => new();
+    public abstract List<string> GetEnumNames();
+    public abstract List<object> GetEnumValues();
     protected internal abstract TypeInfo GetEnumUnderlyingType();
 
     protected internal abstract MethodInfo GetParseMethod();

--- a/test/Routine.Test/Engine/Context/DefaultCoreContextTest.cs
+++ b/test/Routine.Test/Engine/Context/DefaultCoreContextTest.cs
@@ -1,6 +1,6 @@
-using Routine.Core.Cache;
-using Routine.Engine.Context;
 using Routine.Engine;
+using Routine.Engine.Context;
+using Routine.Engine.Reflection;
 using Routine.Test.Core;
 using Routine.Test.Engine.Context.Domain;
 
@@ -9,19 +9,33 @@ namespace Routine.Test.Engine.Context;
 [TestFixture]
 public class DefaultCoreContextTest : CoreTestBase
 {
+    private ICoreContext testing;
+
+    [SetUp]
+    public override void SetUp()
+    {
+        base.SetUp();
+
+        var codingStyle = BuildRoutine.CodingStyle().FromBasic()
+            .AddTypes(GetType().Assembly, t => !string.IsNullOrEmpty(t.Namespace) && t.Namespace.StartsWith("Routine.Test.Engine.Context.Domain"))
+            .IdExtractor.Set(c => c.IdByProperty(m => m.Returns<string>("Id")))
+            .Locator.Set(c => c.Locator(l => l.Constant(null)))
+            .ValueExtractor.Set(c => c.Value(e => e.By(obj => $"{obj}")));
+
+        testing = new DefaultCoreContext(codingStyle);
+    }
+
+    [Test]
+    public void Cannot_access_a_domain_type_before_context_is_initialized()
+    {
+        Assert.Throws<InvalidOperationException>(() => { var _ = testing.DomainTypes; });
+        Assert.Throws<InvalidOperationException>(() => testing.GetDomainType(type.of<CachedBusiness>()));
+    }
+
     [Test]
     public void Caches_domain_types_by_object_model_id()
     {
-        ICodingStyle codingStyle =
-            BuildRoutine.CodingStyle().FromBasic()
-                .AddTypes(GetType().Assembly, t => !string.IsNullOrEmpty(t.Namespace) && t.Namespace.StartsWith("Routine.Test.Engine.Context.Domain"))
-                .IdExtractor.Set(c => c.IdByProperty(m => m.Returns<string>("Id")))
-                .Locator.Set(c => c.Locator(l => l.Constant(null)))
-                .ValueExtractor.Set(c => c.Value(e => e.By(obj => $"{obj}")));
-
-        var testing = new DefaultCoreContext(codingStyle, new DictionaryCache());
-
-        testing.GetDomainTypes();
+        testing.BuildDomainTypes();
 
         var domainType = testing.GetDomainType(type.of<CachedBusiness>());
 
@@ -29,5 +43,30 @@ public class DefaultCoreContextTest : CoreTestBase
         var actual = testing.GetDomainType(domainType.Id);
 
         Assert.AreSame(expected, actual);
+    }
+
+    [Test]
+    public void Build_domain_types_rebuilds_everytime_it_is_called()
+    {
+        testing.BuildDomainTypes();
+        var oldDomainType = testing.GetDomainType(type.of<CachedBusiness>());
+
+        testing.BuildDomainTypes();
+        var newDomainType = testing.GetDomainType(type.of<CachedBusiness>());
+
+        Assert.AreNotSame(oldDomainType, newDomainType);
+    }
+
+    [Test]
+    public void Adding_a_type_later_on_is_reflected_over_existing_proxy_types_of_existing_members()
+    {
+        var codingStyle = BuildRoutine.CodingStyle().FromBasic().AddTypes(typeof(CachedBusiness));
+        var proxyOverAProperty = (ProxyTypeInfo)type.of<CachedBusiness>().GetProperty(nameof(CachedBusiness.LaterAddedType)).PropertyType;
+
+        Assert.IsInstanceOf<ReflectedTypeInfo>(proxyOverAProperty.Real);
+
+        codingStyle.AddTypes(typeof(LaterAddedType));
+
+        Assert.IsInstanceOf<OptimizedTypeInfo>(proxyOverAProperty.Real);
     }
 }

--- a/test/Routine.Test/Engine/Context/DefaultCoreContextTest.cs
+++ b/test/Routine.Test/Engine/Context/DefaultCoreContextTest.cs
@@ -30,31 +30,4 @@ public class DefaultCoreContextTest : CoreTestBase
 
         Assert.AreSame(expected, actual);
     }
-
-    [Test]
-    public void Refreshes_added_types_within_coding_style_when_a_new_type_is_added_so_that_old_IType_instances_are_not_stored()
-    {
-        var codingStyle =
-            BuildRoutine.CodingStyle().FromBasic()
-                .AddTypes(typeof(CachedBusiness))
-                .IdExtractor.Set(c => c.IdByProperty(m => m.Returns<string>("Id")))
-                .Locator.Set(c => c.Locator(l => l.Constant(null)))
-                .ValueExtractor.Set(c => c.Value(e => e.By(obj => $"{obj}")));
-
-        var testing = new DefaultCoreContext(codingStyle, new DictionaryCache());
-
-        testing.GetDomainTypes();
-
-        var expected = testing.GetDomainType(type.of<CachedBusiness>());
-
-        codingStyle.AddTypes(typeof(LaterAddedType));
-
-        testing = new DefaultCoreContext(codingStyle, new DictionaryCache());
-
-        testing.GetDomainTypes();
-
-        var actual = testing.GetDomainType(type.of<CachedBusiness>());
-
-        Assert.AreNotSame(expected.Type, actual.Type);
-    }
 }

--- a/test/Routine.Test/Engine/Context/Domain/CachedBusiness.cs
+++ b/test/Routine.Test/Engine/Context/Domain/CachedBusiness.cs
@@ -3,4 +3,5 @@ namespace Routine.Test.Engine.Context.Domain;
 public class CachedBusiness
 {
     public string Id { get; set; }
+    public LaterAddedType LaterAddedType { get; set; }
 }

--- a/test/Routine.Test/Engine/ObjectServiceTestBase.cs
+++ b/test/Routine.Test/Engine/ObjectServiceTestBase.cs
@@ -36,10 +36,8 @@ public abstract class ObjectServiceTestBase : CoreTestBase
             .NextLayer()
             ;
 
-        var cache = new DictionaryCache();
-        ctx = new DefaultCoreContext(codingStyle, cache);
-
-        testing = new ObjectService(ctx, cache);
+        ctx = new DefaultCoreContext(codingStyle);
+        testing = new ObjectService(ctx, new DictionaryCache());
     }
 
     protected void AddToRepository(object obj)

--- a/test/Routine.Test/Engine/Reflection/ProxyTypeInfoTest.cs
+++ b/test/Routine.Test/Engine/Reflection/ProxyTypeInfoTest.cs
@@ -1,0 +1,11 @@
+namespace Routine.Test.Engine.Reflection;
+
+[TestFixture]
+public class ProxyTypeInfoTest
+{
+    [Test]
+    public void Write_tests()
+    {
+        Assert.Fail("not tested");
+    }
+}

--- a/test/Routine.Test/Engine/Reflection/ProxyTypeInfoTest.cs
+++ b/test/Routine.Test/Engine/Reflection/ProxyTypeInfoTest.cs
@@ -1,11 +1,124 @@
+using System.Linq.Expressions;
+using Routine.Engine.Reflection;
+
 namespace Routine.Test.Engine.Reflection;
 
 [TestFixture]
 public class ProxyTypeInfoTest
 {
-    [Test]
-    public void Write_tests()
+    #region Helpers
+
+    private void TestProxy(Expression<Action<TypeInfo>> expression)
     {
-        Assert.Fail("not tested");
+        var mock = new Mock<TypeInfo>();
+        var testing = new ProxyTypeInfo(mock.Object);
+
+        expression.Compile()(testing);
+        mock.Verify(expression);
+    }
+
+    private void TestProxy<T>(Expression<Func<TypeInfo, T>> expression)
+    {
+        var mock = new Mock<TypeInfo>();
+        var testing = new ProxyTypeInfo(mock.Object);
+
+        expression.Compile()(testing);
+        mock.Verify(expression);
+    }
+
+    #endregion
+
+    [Test]
+    public void Forwards_properties_to_the_real_object()
+    {
+        var @void = new ProxyTypeInfo(type.ofvoid());
+        var @int = new ProxyTypeInfo(type.of<int>());
+        var dayOfWeek = new ProxyTypeInfo(type.of<DayOfWeek>());
+        var @string = new ProxyTypeInfo(type.of<string>());
+        var attribute = new ProxyTypeInfo(type.of<Attribute>());
+        var iList = new ProxyTypeInfo(type.of<IList>());
+        var listString = new ProxyTypeInfo(type.of<List<string>>());
+        var stringArray = new ProxyTypeInfo(type.of<string[]>());
+
+        Assert.That(@string.GetActualType(), Is.EqualTo(typeof(string)));
+
+        Assert.That(@string.IsPublic, Is.True);
+
+        Assert.That(@string.IsAbstract, Is.False);
+        Assert.That(attribute.IsAbstract, Is.True);
+
+        Assert.That(@string.IsInterface, Is.False);
+        Assert.That(attribute.IsInterface, Is.False);
+        Assert.That(iList.IsInterface, Is.True);
+
+        Assert.That(@string.IsValueType, Is.False);
+        Assert.That(@int.IsValueType, Is.True);
+
+        Assert.That(@string.IsGenericType, Is.False);
+        Assert.That(listString.IsGenericType, Is.True);
+
+        Assert.That(@string.IsPrimitive, Is.False);
+        Assert.That(@int.IsPrimitive, Is.True);
+
+        Assert.That(@void.IsVoid, Is.True);
+        Assert.That(@string.IsVoid, Is.False);
+
+        Assert.That(@string.IsEnum, Is.False);
+        Assert.That(dayOfWeek.IsEnum, Is.True);
+
+        Assert.That(@string.IsArray, Is.False);
+        Assert.That(stringArray.IsArray, Is.True);
+
+        Assert.That(@string.Name, Is.EqualTo("String"));
+        Assert.That(@string.FullName, Is.EqualTo("System.String"));
+        Assert.That(@string.Namespace, Is.EqualTo("System"));
+        Assert.That(@string.BaseType.GetActualType(), Is.EqualTo(typeof(object)));
+    }
+
+    [Test]
+    public void Forwards_methods_to_the_real_object()
+    {
+        TestProxy(ti => ti.GetAllConstructors());
+        TestProxy(ti => ti.GetAllProperties());
+        TestProxy(ti => ti.GetAllStaticProperties());
+        TestProxy(ti => ti.GetAllMethods());
+        TestProxy(ti => ti.GetAllStaticMethods());
+        TestProxy(ti => ti.GetCustomAttributes());
+        TestProxy(ti => ti.GetGenericArguments());
+        TestProxy(ti => ti.GetElementType());
+        TestProxy(ti => ti.GetInterfaces());
+        TestProxy(ti => ti.CanBe(It.IsAny<TypeInfo>()));
+        TestProxy(ti => ti.GetEnumNames());
+        TestProxy(ti => ti.GetEnumValues());
+        TestProxy(ti => ti.GetEnumUnderlyingType());
+        TestProxy(ti => ti.GetParseMethod());
+        TestProxy(ti => ti.Load());
+        TestProxy(ti => ti.CreateInstance());
+        TestProxy(ti => ti.CreateListInstance(It.IsAny<int>()));
+        TestProxy(ti => ti.GetAssignableTypes());
+        TestProxy(ti => ti.GetPublicConstructors());
+        TestProxy(ti => ti.GetConstructor(It.IsAny<TypeInfo[]>()));
+        TestProxy(ti => ti.GetPublicProperties(It.IsAny<bool>()));
+        TestProxy(ti => ti.GetPublicStaticProperties(It.IsAny<bool>()));
+        TestProxy(ti => ti.GetProperty(It.IsAny<string>()));
+        TestProxy(ti => ti.GetProperties(It.IsAny<string>()));
+        TestProxy(ti => ti.GetStaticProperty(It.IsAny<string>()));
+        TestProxy(ti => ti.GetStaticProperties(It.IsAny<string>()));
+        TestProxy(ti => ti.GetPublicMethods());
+        TestProxy(ti => ti.GetPublicStaticMethods());
+        TestProxy(ti => ti.GetMethod(It.IsAny<string>()));
+        TestProxy(ti => ti.GetMethods(It.IsAny<string>()));
+        TestProxy(ti => ti.GetStaticMethod(It.IsAny<string>()));
+        TestProxy(ti => ti.GetStaticMethods(It.IsAny<string>()));
+    }
+
+    [Test]
+    public void Real_object_can_be_changed_later()
+    {
+        var testing = new ProxyTypeInfo(type.of<string>());
+
+        testing.SetReal(type.of<int>());
+
+        Assert.That(testing.GetActualType(), Is.EqualTo(typeof(int)));
     }
 }

--- a/test/Routine.Test/Engine/Reflection/ProxyTypeInfoTest.cs
+++ b/test/Routine.Test/Engine/Reflection/ProxyTypeInfoTest.cs
@@ -1,32 +1,15 @@
-using System.Linq.Expressions;
-using Routine.Engine.Reflection;
+﻿using Routine.Engine.Reflection;
 
 namespace Routine.Test.Engine.Reflection;
 
 [TestFixture]
-public class ProxyTypeInfoTest
+public class ProxyTypeInfoTest : ReflectionTestBase
 {
-    #region Helpers
-
-    private void TestProxy(Expression<Action<TypeInfo>> expression)
+    [SetUp]
+    public override void SetUp()
     {
-        var mock = new Mock<TypeInfo>();
-        var testing = new ProxyTypeInfo(mock.Object);
-
-        expression.Compile()(testing);
-        mock.Verify(expression);
+        base.SetUp();
     }
-
-    private void TestProxy<T>(Expression<Func<TypeInfo, T>> expression)
-    {
-        var mock = new Mock<TypeInfo>();
-        var testing = new ProxyTypeInfo(mock.Object);
-
-        expression.Compile()(testing);
-        mock.Verify(expression);
-    }
-
-    #endregion
 
     [Test]
     public void Forwards_properties_to_the_real_object()
@@ -69,47 +52,47 @@ public class ProxyTypeInfoTest
         Assert.That(@string.IsArray, Is.False);
         Assert.That(stringArray.IsArray, Is.True);
 
-        Assert.That(@string.Name, Is.EqualTo("String"));
-        Assert.That(@string.FullName, Is.EqualTo("System.String"));
-        Assert.That(@string.Namespace, Is.EqualTo("System"));
+        Assert.That(@string.Name, Is.EqualTo(typeof(string).Name));
+        Assert.That(@string.FullName, Is.EqualTo(typeof(string).FullName));
+        Assert.That(@string.Namespace, Is.EqualTo(typeof(string).Namespace));
         Assert.That(@string.BaseType.GetActualType(), Is.EqualTo(typeof(object)));
     }
 
     [Test]
     public void Forwards_methods_to_the_real_object()
     {
-        TestProxy(ti => ti.GetAllConstructors());
-        TestProxy(ti => ti.GetAllProperties());
-        TestProxy(ti => ti.GetAllStaticProperties());
-        TestProxy(ti => ti.GetAllMethods());
-        TestProxy(ti => ti.GetAllStaticMethods());
-        TestProxy(ti => ti.GetCustomAttributes());
-        TestProxy(ti => ti.GetGenericArguments());
-        TestProxy(ti => ti.GetElementType());
-        TestProxy(ti => ti.GetInterfaces());
-        TestProxy(ti => ti.CanBe(It.IsAny<TypeInfo>()));
-        TestProxy(ti => ti.GetEnumNames());
-        TestProxy(ti => ti.GetEnumValues());
-        TestProxy(ti => ti.GetEnumUnderlyingType());
-        TestProxy(ti => ti.GetParseMethod());
-        TestProxy(ti => ti.Load());
-        TestProxy(ti => ti.CreateInstance());
-        TestProxy(ti => ti.CreateListInstance(It.IsAny<int>()));
-        TestProxy(ti => ti.GetAssignableTypes());
-        TestProxy(ti => ti.GetPublicConstructors());
-        TestProxy(ti => ti.GetConstructor(It.IsAny<TypeInfo[]>()));
-        TestProxy(ti => ti.GetPublicProperties(It.IsAny<bool>()));
-        TestProxy(ti => ti.GetPublicStaticProperties(It.IsAny<bool>()));
-        TestProxy(ti => ti.GetProperty(It.IsAny<string>()));
-        TestProxy(ti => ti.GetProperties(It.IsAny<string>()));
-        TestProxy(ti => ti.GetStaticProperty(It.IsAny<string>()));
-        TestProxy(ti => ti.GetStaticProperties(It.IsAny<string>()));
-        TestProxy(ti => ti.GetPublicMethods());
-        TestProxy(ti => ti.GetPublicStaticMethods());
-        TestProxy(ti => ti.GetMethod(It.IsAny<string>()));
-        TestProxy(ti => ti.GetMethods(It.IsAny<string>()));
-        TestProxy(ti => ti.GetStaticMethod(It.IsAny<string>()));
-        TestProxy(ti => ti.GetStaticMethods(It.IsAny<string>()));
+        CallOnProxyAndVerifyOnMock(ti => ti.GetAllConstructors());
+        CallOnProxyAndVerifyOnMock(ti => ti.GetAllProperties());
+        CallOnProxyAndVerifyOnMock(ti => ti.GetAllStaticProperties());
+        CallOnProxyAndVerifyOnMock(ti => ti.GetAllMethods());
+        CallOnProxyAndVerifyOnMock(ti => ti.GetAllStaticMethods());
+        CallOnProxyAndVerifyOnMock(ti => ti.GetCustomAttributes());
+        CallOnProxyAndVerifyOnMock(ti => ti.GetGenericArguments());
+        CallOnProxyAndVerifyOnMock(ti => ti.GetElementType());
+        CallOnProxyAndVerifyOnMock(ti => ti.GetInterfaces());
+        CallOnProxyAndVerifyOnMock(ti => ti.CanBe(It.IsAny<TypeInfo>()));
+        CallOnProxyAndVerifyOnMock(ti => ti.GetEnumNames());
+        CallOnProxyAndVerifyOnMock(ti => ti.GetEnumValues());
+        CallOnProxyAndVerifyOnMock(ti => ti.GetEnumUnderlyingType());
+        CallOnProxyAndVerifyOnMock(ti => ti.GetParseMethod());
+        CallOnProxyAndVerifyOnMock(ti => ti.Load());
+        CallOnProxyAndVerifyOnMock(ti => ti.CreateInstance());
+        CallOnProxyAndVerifyOnMock(ti => ti.CreateListInstance(It.IsAny<int>()));
+        CallOnProxyAndVerifyOnMock(ti => ti.GetAssignableTypes());
+        CallOnProxyAndVerifyOnMock(ti => ti.GetPublicConstructors());
+        CallOnProxyAndVerifyOnMock(ti => ti.GetConstructor(It.IsAny<TypeInfo[]>()));
+        CallOnProxyAndVerifyOnMock(ti => ti.GetPublicProperties(It.IsAny<bool>()));
+        CallOnProxyAndVerifyOnMock(ti => ti.GetPublicStaticProperties(It.IsAny<bool>()));
+        CallOnProxyAndVerifyOnMock(ti => ti.GetProperty(It.IsAny<string>()));
+        CallOnProxyAndVerifyOnMock(ti => ti.GetProperties(It.IsAny<string>()));
+        CallOnProxyAndVerifyOnMock(ti => ti.GetStaticProperty(It.IsAny<string>()));
+        CallOnProxyAndVerifyOnMock(ti => ti.GetStaticProperties(It.IsAny<string>()));
+        CallOnProxyAndVerifyOnMock(ti => ti.GetPublicMethods());
+        CallOnProxyAndVerifyOnMock(ti => ti.GetPublicStaticMethods());
+        CallOnProxyAndVerifyOnMock(ti => ti.GetMethod(It.IsAny<string>()));
+        CallOnProxyAndVerifyOnMock(ti => ti.GetMethods(It.IsAny<string>()));
+        CallOnProxyAndVerifyOnMock(ti => ti.GetStaticMethod(It.IsAny<string>()));
+        CallOnProxyAndVerifyOnMock(ti => ti.GetStaticMethods(It.IsAny<string>()));
     }
 
     [Test]
@@ -117,7 +100,7 @@ public class ProxyTypeInfoTest
     {
         var testing = new ProxyTypeInfo(type.of<string>());
 
-        testing.SetReal(type.of<int>());
+        testing.Real = type.of<int>();
 
         Assert.That(testing.GetActualType(), Is.EqualTo(typeof(int)));
     }

--- a/test/Routine.Test/Engine/Reflection/ReflectionTestBase.cs
+++ b/test/Routine.Test/Engine/Reflection/ReflectionTestBase.cs
@@ -1,4 +1,5 @@
-﻿using Routine.Engine.Reflection;
+﻿using System.Linq.Expressions;
+using Routine.Engine.Reflection;
 using Routine.Test.Core;
 using Routine.Test.Engine.Reflection.Domain;
 
@@ -81,4 +82,22 @@ public abstract class ReflectionTestBase : CoreTestBase
     protected PropertyInfo Attribute_InterfaceProperty(string prefixOrFullName) =>
         type.of<TestInterface_Attribute>().GetProperty($"{prefixOrFullName}Property") ??
         type.of<TestInterface_Attribute>().GetProperty(prefixOrFullName);
+
+    protected void CallOnProxyAndVerifyOnMock(Expression<Action<TypeInfo>> expression)
+    {
+        var mock = new Mock<TypeInfo>();
+        var testing = new ProxyTypeInfo(mock.Object);
+
+        expression.Compile()(testing);
+        mock.Verify(expression);
+    }
+
+    protected void CallOnProxyAndVerifyOnMock<T>(Expression<Func<TypeInfo, T>> expression)
+    {
+        var mock = new Mock<TypeInfo>();
+        var testing = new ProxyTypeInfo(mock.Object);
+
+        expression.Compile()(testing);
+        mock.Verify(expression);
+    }
 }

--- a/test/Routine.Test/Engine/Reflection/TypeInfoTest.cs
+++ b/test/Routine.Test/Engine/Reflection/TypeInfoTest.cs
@@ -4,6 +4,7 @@ using Routine.Test.Engine.Reflection.Domain;
 using RoutineTest.OuterDomainNamespace;
 using RoutineTest.OuterNamespace;
 using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 
 namespace Routine.Test.Engine.Reflection;
 
@@ -67,6 +68,20 @@ public class TypeInfoTest : ReflectionTestBase
         property = TypeInfo.Get<TestOuterDomainType_OOP>().GetAllProperties().First(p => p.Returns<TestOuterLaterAddedDomainType_OOP>());
 
         Assert.IsInstanceOf<OptimizedTypeInfo>(property.PropertyType);
+    }
+
+    [Test]
+    public void When_a_type_is_loaded_in_two_different_load_contexts__old_one_should_be_matched_from_its_full_name_and_invalidated()
+    {
+        var typeFromDifferentLoadContext = Assembly.LoadFile(GetType().Assembly.Location).GetType(typeof(TestOuterDomainType_OOP).FullName);
+
+        TypeInfo.Optimize(typeFromDifferentLoadContext);
+        TypeInfo.Optimize(typeof(TestOuterDomainType_OOP));
+
+        var actual = TypeInfo.Get(typeFromDifferentLoadContext);
+        var expected = TypeInfo.Get<TestOuterDomainType_OOP>();
+
+        Assert.AreSame(expected, actual);
     }
 
     [Test]

--- a/test/Routine.Test/Engine/Reflection/TypeInfoTest.cs
+++ b/test/Routine.Test/Engine/Reflection/TypeInfoTest.cs
@@ -3,7 +3,6 @@ using Routine.Engine;
 using Routine.Test.Engine.Reflection.Domain;
 using RoutineTest.OuterDomainNamespace;
 using RoutineTest.OuterNamespace;
-using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 namespace Routine.Test.Engine.Reflection;
@@ -236,7 +235,7 @@ public class TypeInfoTest : ReflectionTestBase
         catch (MissingMethodException) { }
     }
 
-    [Test, SuppressMessage("ReSharper", "LocalVariableHidesMember")]
+    [Test]
     public void TypeInfo_lists_custom_attributes_with_inherit_behaviour()
     {
         var systemType = typeof(TestClass_Attribute);
@@ -450,7 +449,7 @@ public class TypeInfoTest : ReflectionTestBase
         Assert.IsFalse(type.of<TestClass_NotParseable>().CanParse());
     }
 
-    [Test, SuppressMessage("ReSharper", "SpecifyACultureInStringConversionExplicitly")]
+    [Test]
     public void Extension_Parse()
     {
         Assert.AreEqual('c', type.of<char>().Parse('c'.ToString()));


### PR DESCRIPTION
Zaman zaman oluşan `__routine_void was attempted to be added more than once.`
hatasının giderilmesi işidir.

## İşler

- [x] `__routine_void` hatası oluşamayacak şekilde kodun düzenlenmesi
  - [x] Type eklerken ayni type'i farkli load context ile alip, hashset'lerin
    ve dictionary'lerin hatayi uretmesini saglayip, sonra da sorunu fullname
    uzerinden cozmeli
  - [x] codingstyle'daki types refreshi refactor edilecek, oradaki todo
    cozulecek
  - [x] ~TypeInfo.GetOptimizedTypes icin daha iyi bir public api hazirlanacak
    ve test edilecek~ sadece one to one mapping icin gazel'de kullaniliyordu,
    ve codingstyle'da gettypes diye alternatifi var, silindi
  - [x] `ObjectService`'teki cache'leme işi gözden geçirilecek
  - [x] `DefaultCoreContext`in cache'in temizlenme durumunda tekrar yüklemesi
    sağlanmalı ya da cache kullanimi iptal edilmeli
  - [x] Sonradan add type yapmanin eski typeinfo ve property'ye erisime sebep
    olmadigi kontrol edilecek, yani silinen farkli olma testi domain type icin
    tekrar yazilmali, sonradan add type yapilmali ve IProperty instance'i
    yenilenmis mi bakilmali
- [x] Reflection optimizer'in devreye girdiyi test edilecek
- [x] Initialize'da tek seferlik hata simüle edilecek, uygulamanın ikincide
  toparlayabildiği doğrulanacak
