### PR TITLE
Bug / Proxy Matcher Clear

### DIFF
--- a/samples/Routine.Samples.Basic/Properties/launchSettings.json
+++ b/samples/Routine.Samples.Basic/Properties/launchSettings.json
@@ -3,7 +3,7 @@
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "http://localhost:30549",
+      "applicationUrl": "http://localhost:5000",
       "sslPort": 44382
     }
   },

--- a/src/Routine/Engine/Configuration/ConventionBased/ConventionBasedCodingStyle.cs
+++ b/src/Routine/Engine/Configuration/ConventionBased/ConventionBasedCodingStyle.cs
@@ -40,8 +40,6 @@ public class ConventionBasedCodingStyle : LayeredBase<ConventionBasedCodingStyle
 
     public ConventionBasedCodingStyle()
     {
-        TypeInfo.Clear();
-
         _types = new();
 
         MaxFetchDepth = new(this, nameof(MaxFetchDepth), true);

--- a/test/Routine.Test/Core/Configuration/ConventionBasedConfigurationTest.cs
+++ b/test/Routine.Test/Core/Configuration/ConventionBasedConfigurationTest.cs
@@ -278,18 +278,4 @@ public class ConventionBasedConfigurationTest : CoreTestBase
         Assert.AreEqual(typeBefore, typeAfter);
 
     }
-
-    [Test]
-    public void Bug_type_info_clear_causes_reset_in_proxy_matcher()
-    {
-        var conventionBasedCodingStyle = new ConventionBasedCodingStyle();
-        conventionBasedCodingStyle.RecognizeProxyTypesBy(t => true, t => t.BaseType);
-        var typeBefore = TypeInfo.Get<string>();
-
-        TypeInfo.Clear();
-        var typeAfter = TypeInfo.Get<string>();
-
-        Assert.AreEqual(typeBefore, typeAfter);
-
-    }
 }

--- a/test/Routine.Test/Core/Configuration/ConventionBasedConfigurationTest.cs
+++ b/test/Routine.Test/Core/Configuration/ConventionBasedConfigurationTest.cs
@@ -272,9 +272,21 @@ public class ConventionBasedConfigurationTest : CoreTestBase
         conventionBasedCodingStyle.RecognizeProxyTypesBy(t => true, t => t.BaseType);
         var typeBefore = TypeInfo.Get<string>();
 
-        //BuildRoutine.CodingStylePattern().FromEmpty();
+        BuildRoutine.CodingStylePattern().FromEmpty();
+        var typeAfter = TypeInfo.Get<string>();
+
+        Assert.AreEqual(typeBefore, typeAfter);
+
+    }
+
+    [Test]
+    public void Bug_type_info_clear_causes_reset_in_proxy_matcher()
+    {
+        var conventionBasedCodingStyle = new ConventionBasedCodingStyle();
+        conventionBasedCodingStyle.RecognizeProxyTypesBy(t => true, t => t.BaseType);
+        var typeBefore = TypeInfo.Get<string>();
+
         TypeInfo.Clear();
-        //conventionBasedCodingStyle.AddTypes(typeof(string));
         var typeAfter = TypeInfo.Get<string>();
 
         Assert.AreEqual(typeBefore, typeAfter);

--- a/test/Routine.Test/Core/Configuration/ConventionBasedConfigurationTest.cs
+++ b/test/Routine.Test/Core/Configuration/ConventionBasedConfigurationTest.cs
@@ -1,5 +1,6 @@
-﻿using Routine.Core.Configuration.Convention;
-using Routine.Core.Configuration;
+﻿using Routine.Core.Configuration;
+using Routine.Core.Configuration.Convention;
+using Routine.Engine.Configuration.ConventionBased;
 
 namespace Routine.Test.Core.Configuration;
 
@@ -8,7 +9,7 @@ public class ConventionBasedConfigurationTest : CoreTestBase
 {
     #region Setup & Helpers
 
-    private Mock<ILayered> _layeredMock; 
+    private Mock<ILayered> _layeredMock;
     private Mock<ILayered> _otherLayeredMock;
 
     private ConventionBasedConfiguration<ILayered, string, string> _testing;
@@ -262,5 +263,21 @@ public class ConventionBasedConfigurationTest : CoreTestBase
     {
         //BeginTest();
         Assert.Fail();
+    }
+
+    [Test]
+    public void Bug_pattern_builder_causes_reset_in_proxy_matcher()
+    {
+        var conventionBasedCodingStyle = new ConventionBasedCodingStyle();
+        conventionBasedCodingStyle.RecognizeProxyTypesBy(t => true, t => t.BaseType);
+        var typeBefore = TypeInfo.Get<string>();
+
+        //BuildRoutine.CodingStylePattern().FromEmpty();
+        TypeInfo.Clear();
+        //conventionBasedCodingStyle.AddTypes(typeof(string));
+        var typeAfter = TypeInfo.Get<string>();
+
+        Assert.AreEqual(typeBefore, typeAfter);
+
     }
 }

--- a/test/Routine.Test/Core/Configuration/ConventionBasedConfigurationTest.cs
+++ b/test/Routine.Test/Core/Configuration/ConventionBasedConfigurationTest.cs
@@ -28,6 +28,8 @@ public class ConventionBasedConfigurationTest : CoreTestBase
 
         _layeredMock.Setup(o => o.CurrentLayer).Returns(Layer.LeastSpecific);
         _otherLayeredMock.Setup(o => o.CurrentLayer).Returns(Layer.LeastSpecific);
+
+        TypeInfo.Clear();
     }
 
     private void SetMoreSpecificLayer()

--- a/test/Routine.Test/Core/Configuration/ConventionBasedConfigurationTest.cs
+++ b/test/Routine.Test/Core/Configuration/ConventionBasedConfigurationTest.cs
@@ -28,8 +28,6 @@ public class ConventionBasedConfigurationTest : CoreTestBase
 
         _layeredMock.Setup(o => o.CurrentLayer).Returns(Layer.LeastSpecific);
         _otherLayeredMock.Setup(o => o.CurrentLayer).Returns(Layer.LeastSpecific);
-
-        TypeInfo.Clear();
     }
 
     private void SetMoreSpecificLayer()
@@ -268,16 +266,14 @@ public class ConventionBasedConfigurationTest : CoreTestBase
     }
 
     [Test]
-    public void Bug_pattern_builder_causes_reset_in_proxy_matcher()
+    public void BUG_pattern_builder_causes_reset_in_proxy_matcher()
     {
         var conventionBasedCodingStyle = new ConventionBasedCodingStyle();
-        conventionBasedCodingStyle.RecognizeProxyTypesBy(t => true, t => t.BaseType);
-        var typeBefore = TypeInfo.Get<string>();
+        conventionBasedCodingStyle.RecognizeProxyTypesBy(t => true, t => typeof(object));
 
         BuildRoutine.CodingStylePattern().FromEmpty();
-        var typeAfter = TypeInfo.Get<string>();
+        var typeAfter = type.of<string>();
 
-        Assert.AreEqual(typeBefore, typeAfter);
-
+        Assert.AreEqual(type.of<object>(), typeAfter);
     }
 }

--- a/test/Routine.Test/Core/Configuration/ConventionBasedConfigurationTest.cs
+++ b/test/Routine.Test/Core/Configuration/ConventionBasedConfigurationTest.cs
@@ -8,7 +8,7 @@ public class ConventionBasedConfigurationTest : CoreTestBase
 {
     #region Setup & Helpers
 
-    private Mock<ILayered> _layeredMock;
+    private Mock<ILayered> _layeredMock; 
     private Mock<ILayered> _otherLayeredMock;
 
     private ConventionBasedConfiguration<ILayered, string, string> _testing;

--- a/test/Routine.Test/Core/CoreTestBase.cs
+++ b/test/Routine.Test/Core/CoreTestBase.cs
@@ -13,6 +13,7 @@ public abstract class CoreTestBase
     [SetUp]
     public virtual void SetUp()
     {
+        TypeInfo.Clear();
         TypeInfo.SetProxyMatcher(t => t.Name.Contains("Proxy"), t => t.BaseType);
 
         _objectModelDictionary = new();

--- a/test/Routine.Test/Engine/Context/DefaultCoreContextTest.cs
+++ b/test/Routine.Test/Engine/Context/DefaultCoreContextTest.cs
@@ -23,6 +23,8 @@ public class DefaultCoreContextTest : CoreTestBase
             .ValueExtractor.Set(c => c.Value(e => e.By(obj => $"{obj}")));
 
         _testing = new DefaultCoreContext(codingStyle);
+
+        TypeInfo.Clear();
     }
 
     [Test]


### PR DESCRIPTION
TypeInfo'nun proxyMatcher ve actualTypeGetter'ı set edildikten sonra pattern builder kullanınca proxy matcher resetlenmesinin düzeltilmesi.

## İşler

- [x] Case, Unit Test olarak oluşturulacak