### PR TITLE
issue / production-mode-code-compiler-refactor

### DIFF
--- a/.github/workflows/project-regular-checks.yml
+++ b/.github/workflows/project-regular-checks.yml
@@ -91,7 +91,7 @@ jobs:
           output: 'both'
       - name: Upload Reports
         if: ${{ matrix.os == 'ubuntu-latest' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-reports
           path: code-coverage-results.md
@@ -101,7 +101,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download Reports
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: coverage-reports
       - name: Write to Job Summary

--- a/.github/workflows/project-regular-checks.yml
+++ b/.github/workflows/project-regular-checks.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: |
-            6.0.x
+            8.0.x
       - name: Build Solution
         run: dotnet build -c Release
   test:
@@ -59,7 +59,7 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: |
-            6.0.x
+            8.0.x
       - name: Test
         if: ${{ matrix.os != 'ubuntu-latest' }}
         run: dotnet test -c Release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,7 +73,7 @@ jobs:
             -o "package" \
             -c Release
       - name: Upload Package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: package
           path: package/Routine.${{ needs.check-version.outputs.version }}.nupkg
@@ -83,7 +83,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download Package
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: package
       - name: Push

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,7 +66,7 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: |
-            6.0.x
+            8.0.x
       - name: Pack
         run: |
           dotnet pack "src/Routine/Routine.csproj" \

--- a/src/Routine/Core/Reflection/OptimizedMethodInvokerTemplate.cs
+++ b/src/Routine/Core/Reflection/OptimizedMethodInvokerTemplate.cs
@@ -2,7 +2,7 @@
 
 namespace Routine.Core.Reflection;
 
-public class OptimizedMethodInvokerTemplate : IDisposable
+public sealed class OptimizedMethodInvokerTemplate : IDisposable
 {
     private readonly MethodBase _method;
     private readonly InvocationType _invocationType;
@@ -180,9 +180,18 @@ public class OptimizedMethodInvokerTemplate : IDisposable
     private static string NameOf<T>() => NameOf(typeof(T));
     private static string NameOf(Type type) => type.ToCSharpString();
 
+    private void ReleaseUnmanagedResources()
+    {
+    }
+
     public void Dispose()
     {
-        // TODO release managed resources here
+        ReleaseUnmanagedResources();
         GC.SuppressFinalize(this);
+    }
+
+    ~OptimizedMethodInvokerTemplate()
+    {
+        ReleaseUnmanagedResources();
     }
 }

--- a/src/Routine/Core/Reflection/ReflectionOptimizer.cs
+++ b/src/Routine/Core/Reflection/ReflectionOptimizer.cs
@@ -82,6 +82,12 @@ internal class ReflectionOptimizer
     {
         var result = new Dictionary<MethodBase, IMethodInvoker>();
 
+        if (_methods.Count == 0)
+        {
+            Optimized?.Invoke(null, EventArgs.Empty);
+            return result;
+        }
+
         var compiler = new CodeCompiler();
 
         compiler.AddReferenceFrom<IMethodInvoker>();
@@ -104,11 +110,11 @@ internal class ReflectionOptimizer
                 continue;
             }
 
-            var template = new OptimizedMethodInvokerTemplate(method);
-
-            methodsByName[template.InvokerTypeName] = method;
-
-            compiler.AddCode(template.Render());
+            using (var template = new OptimizedMethodInvokerTemplate(method))
+            {
+                methodsByName[template.InvokerTypeName] = method;
+                compiler.AddCode(template.Render());
+            }
 
             compiler.AddReferenceFrom(method.ReflectedType);
             compiler.AddReferenceFrom(method.DeclaringType);

--- a/test/Routine.Test/Core/Reflection/ReflectionOptimizerAsyncTest.cs
+++ b/test/Routine.Test/Core/Reflection/ReflectionOptimizerAsyncTest.cs
@@ -21,7 +21,6 @@ public class ReflectionOptimizerAsyncTest : ReflectionOptimizerContract
     }
 
     [Test]
-    [Ignore(".net8 upgrade")]
     public async Task Awaits_async_methods()
     {
         var testing = InvokerFor<OptimizedClass>(nameof(OptimizedClass.AsyncVoidMethod));

--- a/test/Routine.Test/Core/Reflection/ReflectionOptimizerContract.cs
+++ b/test/Routine.Test/Core/Reflection/ReflectionOptimizerContract.cs
@@ -156,15 +156,15 @@ public abstract class ReflectionOptimizerContract : CoreTestBase
     {
         if (invoker is not ProxyMethodInvoker proxy || proxy.Real is not SwitchableMethodInvoker switchable) { return; }
 
-        const int timeout = 100;
+        //const int timeout = 100;
 
         var count = 0;
         var optimized = switchable.Invoker is not ReflectionMethodInvoker;
         var onOptimized = new EventHandler((_, _) => optimized = true);
         ReflectionOptimizer.Optimized += onOptimized;
-        while (!optimized && count < timeout)
+        while (!optimized)
         {
-            Thread.Sleep(1);
+            Thread.SpinWait(1);
             count++;
         }
         ReflectionOptimizer.Optimized -= onOptimized;
@@ -186,7 +186,6 @@ public abstract class ReflectionOptimizerContract : CoreTestBase
     }
 
     [Test]
-    [Ignore(".net8 upgrade")]
     public void CreateInvoker_returns_a_proxy_invoker_that_has_reflection_invoker_for_app_to_have_faster_startup()
     {
         ReflectionOptimizer.Clear();
@@ -197,6 +196,8 @@ public abstract class ReflectionOptimizerContract : CoreTestBase
         Assert.That(switchable.Invoker, Is.InstanceOf<ReflectionMethodInvoker>());
 
         WaitForOptimization(proxy);
+
+        Assert.That(switchable.Invoker, Is.InstanceOf<IMethodInvoker>());
 
         Assert.That(switchable.Invoker, Is.Not.InstanceOf<ReflectionMethodInvoker>());
     }
@@ -267,7 +268,6 @@ public abstract class ReflectionOptimizerContract : CoreTestBase
     }
 
     [Test]
-    [Ignore(".net8 upgrade")]
     public void Method_invoker_does_not_check_parameter_compatibility_and_let_IndexOutOfRangeException_or_InvalidCastException_to_be_thrown()
     {
         Assert.That(() => Invoke(InvokerFor<OptimizedClass>("OneParameterVoidMethod"), _target),

--- a/test/Routine.Test/Core/Reflection/ReflectionOptimizerSyncTest.cs
+++ b/test/Routine.Test/Core/Reflection/ReflectionOptimizerSyncTest.cs
@@ -8,7 +8,6 @@ public class ReflectionOptimizerSyncTest : ReflectionOptimizerContract
     protected override object Invoke(IMethodInvoker invoker, object target, params object[] args) => invoker.Invoke(target, args);
 
     [Test]
-    [Ignore(".net8 upgrade")]
     public void Waits_for_async_methods_to_run()
     {
         var testing = InvokerFor<OptimizedClass>(nameof(OptimizedClass.AsyncVoidMethod));


### PR DESCRIPTION
## İşler
- [x] CodeCompiler class'ı internal hale getirildi, ReflectionOptimizer dışında referansı yok,
- [x] OptimizedMethodInvokerTemplate içerisinde metodun Name prop'unu get ederken kullanılan GetHashCode() metodu constructor'a taşındı,
- [x] OptimizedMethodInvokerTemplate disposable hale getirildi,
- [x] Unit Testlerde WaitForOptimization metodu, threadi kitlememesi için Thread.SpinWait'e çevrildi ve counter iptal edilip, compilation bitene kadar bekletildi,
- [x] ReflectionOptimizer Optimize metodunda _method obje count'ı 0 ise yeni CodeCompiler instance'ı oluşturması engellendi,
